### PR TITLE
[PRODUCT-CREATOR] `task_queue.enqueue` fails on first call in Cloud Functions due to auth race condition - see issue #6

### DIFF
--- a/firebase_admin/_http_client.py
+++ b/firebase_admin/_http_client.py
@@ -46,7 +46,6 @@ DEFAULT_RETRY_CONFIG = retry.Retry(
 DEFAULT_HTTPX_RETRY_CONFIG = HttpxRetry(
     max_retries=4, status_forcelist=[500, 503], backoff_factor=0.5)
 
-
 DEFAULT_TIMEOUT_SECONDS = 120
 
 METRICS_HEADERS = {
@@ -170,7 +169,7 @@ class GoogleAuthCredentialFlow(httpx.Auth):
     def __init__(self, credential: credentials.Credentials):
         self._credential = credential
         self._max_refresh_attempts = 2
-        self._refresh_status_codes = (401,)
+        self._refresh_status_codes = (401, 403, 400)
 
     def apply_auth_headers(
             self,

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -618,7 +618,8 @@ class TestGoogleAuthCredentialFlow:
 
         responses = [
             respx.MockResponse(401, http_version='HTTP/2', content='Auth error'),
-            respx.MockResponse(401, http_version='HTTP/2', content='Auth error'),
+            respx.MockResponse(400, http_version='HTTP/2', content='Auth error'),
+            respx.MockResponse(403, http_version='HTTP/2', content='Auth error'),
             respx.MockResponse(200, http_version='HTTP/2', content='body'),
         ]
         route = respx.request('POST', _TEST_URL).mock(side_effect=responses)
@@ -626,7 +627,7 @@ class TestGoogleAuthCredentialFlow:
         resp = await client.request('post', _TEST_URL)
         assert resp.status_code == 200
         assert resp.text == 'body'
-        assert route.call_count == 3
+        assert route.call_count == 4
 
         request = route.calls.last.request
         assert request.method == 'POST'
@@ -646,8 +647,9 @@ class TestGoogleAuthCredentialFlow:
 
         responses = [
             respx.MockResponse(401, http_version='HTTP/2', content='Auth error'),
-            respx.MockResponse(401, http_version='HTTP/2', content='Auth error'),
-            respx.MockResponse(401, http_version='HTTP/2', content='Auth error'),
+            respx.MockResponse(400, http_version='HTTP/2', content='Auth error'),
+            respx.MockResponse(403, http_version='HTTP/2', content='Auth error'),
+            respx.MockResponse(403, http_version='HTTP/2', content='Auth error'),
             # Should stop after previous response
             respx.MockResponse(200, http_version='HTTP/2', content='body'),
         ]
@@ -656,11 +658,11 @@ class TestGoogleAuthCredentialFlow:
         with pytest.raises(httpx.HTTPStatusError) as exc_info:
             resp = await client.request('post', _TEST_URL)
         resp = exc_info.value.response
-        assert resp.status_code == 401
+        assert resp.status_code == 403
         assert resp.text == 'Auth error'
-        assert route.call_count == 3
+        assert route.call_count == 4
 
-        assert mock_credential_patch.call_count == 3
+        assert mock_credential_patch.call_count == 4
 
         request = route.calls.last.request
         assert request.method == 'POST'


### PR DESCRIPTION
This pull request addresses the issue where `task_queue.enqueue` fails on the first call in Cloud Functions due to an authentication race condition. For more details, refer to issue #6.